### PR TITLE
Update opentelemetry-instrumentation-system-metrics 0.47b0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-system-metrics" %}
-{% set version = "0.49b2" %}
+{% set version = "0.47b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,23 +7,22 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation_system_metrics-{{ version }}.tar.gz
-  sha256: 2ef4949c0c0f64e6b7437b8d23e0ee57245ab3d0d38501157bb93f4e4151207c
+  sha256: 0c3416cef74dd93fcbcebd51e0fe51e4e7db04151cd5de13e7ab5ae82b19571d
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
+    - python
     - opentelemetry-instrumentation =={{ version }}
     - opentelemetry-api >=1.11,<2.dev0
-    - opentelemetry-sdk >=1.25,<2.0
     - psutil >=5.9.0,<7
 
 test:
@@ -32,18 +31,20 @@ test:
   commands:
     - pip check
   requires:
-    - python {{ python_min }}
     - pip
 
 about:
-  home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-system-metrics.
-  summary: OpenTelemetry System Metrics Instrumentation
+  home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-system-metrics
+  summary: OpenTelemetry Python Instrumentation for System Metrics
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  description: |
+    This package provides entrypoints to configure OpenTelemetry.
+  doc_url: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-system-metrics
+  dev_url: https://pypi.org/project/opentelemetry-instrumentation-system-metrics/
 
 extra:
   recipe-maintainers:
     - rxm7706
-    - conda-forge/opentelemetry-instrumentation
-    - conda-forge/opentelemetry-api
-    - conda-forge/opentelemetry-sdk
+    - arishamays1


### PR DESCRIPTION
## ☆ Opentelemetry-instrumentation-system-metrics 0.47b0☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6096)
[Upstream](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/v0.47b0/instrumentation/opentelemetry-instrumentation-system-metrics/pyproject.toml)

### Changes
 - Updated version number and sha256
 - Updated `about` section
 - Updates to `run` and `host` section
 - `Skip` to Python versions less than 3.8
