### PR TITLE
v0.51b0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
+  - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
+  
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,7 @@
 channels:
   - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
   - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
+  - https://staging.continuum.io/prefect/fs/opentelemetry-instrumentation-feedstock/pr4/10a3ff7
   
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
-  - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
-  - https://staging.continuum.io/prefect/fs/opentelemetry-instrumentation-feedstock/pr4/10a3ff7
-  
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - opentelemetry-instrumentation =={{ version }}
-    - opentelemetry-api >=1.11,<2.dev0
+    - opentelemetry-api >=1.11,<2.0.0.dev0
     - psutil >=5.9.0,<7
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-system-metrics" %}
-{% set version = "0.47b0" %}
+{% set version = "0.51b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation_system_metrics-{{ version }}.tar.gz
-  sha256: 0c3416cef74dd93fcbcebd51e0fe51e4e7db04151cd5de13e7ab5ae82b19571d
+  sha256: 8ff1b9906d5db4b028b599236d11588bb0f791bb23d59fc72bc6cf9b8fbbd4ec
 
 build:
   skip: True # [py<38]


### PR DESCRIPTION
opentelemetry-instrumentation-system-metrics 0.51b

**Destination channel:**  defaults

### Links

- [PKG-7678](https://anaconda.atlassian.net/browse/PKG-7678) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.51b0/instrumentation/opentelemetry-instrumentation-system-metrics)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13
- Update pinnings

[PKG-7678]: https://anaconda.atlassian.net/browse/PKG-7678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ